### PR TITLE
Update console instructions for latest usage format

### DIFF
--- a/kafka-java-console-sample/docs/Local.md
+++ b/kafka-java-console-sample/docs/Local.md
@@ -19,10 +19,10 @@ The command above creates a jar file under `build/libs`.
 ## Running the Sample
 Once built, to run the sample, execute the following command:
 ```shell
-java -jar ./build/libs/kafka-java-console-sample-2.0-all.jar <kafka_brokers_sasl> <api_key>
+java -jar ./build/libs/kafka-java-console-sample-2.0.jar <kafka_brokers_sasl> <api_key>
 ```
 
-To find the values for `<kafka_brokers_sasl>` and `<api_key>`, access your Event Streams instance in IBM Cloud®, go to the `Service Credentials` tab and select the `Credentials` you want to use.  If your user value is `token`, specify that with the password seperated by a `:`.
+To find the values for `<kafka_brokers_sasl>` and `<api_key>`, access your Event Streams instance in IBM Cloud®, go to the `Service Credentials` tab and select the `Credentials` you want to use.
 
 __Note__: `<kafka_brokers_sasl>` must be a single string enclosed in quotes. For example: `"host1:port1,host2:port2"`. We recommend using all the Kafka hosts listed in the `Credentials` you selected.
 


### PR DESCRIPTION
The use of a colon for token users is no longer required
The jar file name no longer has a -all postfix