### PR TITLE
Restore unzip capability to kafka-java-liberty

### DIFF
--- a/kafka-java-liberty-sample/Dockerfile
+++ b/kafka-java-liberty-sample/Dockerfile
@@ -3,13 +3,17 @@ FROM gradle:jdk8-alpine as jdk
 COPY --chown=1000 . /usr/src/app
 WORKDIR /usr/src/app
 
-RUN gradle -s --no-daemon assemble
+USER root
+RUN apk --no-cache add busybox-static \
+  && gradle -s --no-daemon assemble
 
 FROM websphere-liberty:javaee8
 
+COPY --from=jdk /bin/busybox.static /bin/unzip
 COPY --from=jdk --chown=1001:0 /usr/src/app/target/defaultServer/apps/EventStreamsLibertyApp.war /tmp
 COPY --from=jdk --chown=1001:0 /usr/src//app/target/defaultServer/server.xml /config/server.xml
 
-RUN unzip -q /tmp/EventStreamsLibertyApp.war \
+RUN mkdir -p /opt/ibm/wlp/usr/servers/defaultServer/apps/EventStreamsLibertyApp.war \
+  && unzip -q /tmp/EventStreamsLibertyApp.war \
       -d /opt/ibm/wlp/usr/servers/defaultServer/apps/EventStreamsLibertyApp.war \
   && chmod -R a+rwX /opt/ibm/wlp/usr/servers/defaultServer/apps/EventStreamsLibertyApp.war


### PR DESCRIPTION
The upstream image no longer contains `unzip`. Pull-in a statically
compiled unzip via busybox.