### PR TITLE
replace whitespace with underscore

### DIFF
--- a/kafka-java-console-sample/src/main/java/com/eventstreams/samples/ProducerRunnable.java
+++ b/kafka-java-console-sample/src/main/java/com/eventstreams/samples/ProducerRunnable.java
@@ -70,7 +70,7 @@ public class ProducerRunnable implements Runnable {
         try {
             while (!closing) {
                 String key = "key";
-                String message = "{\"message\":\"This is a test message #\",\"message number\":" + producedMessages + "}";
+                String message = "{\"message\":\"This is a test message #\",\"message_number\":" + producedMessages + "}";
 
                 try {
                     // If a partition is not specified, the client will use the default partitioner to choose one.


### PR DESCRIPTION
this whitespace in the key caused sql query job is not able to parse message.

and we use underscore in other places, so to be consistent:
eg. schema
https://github.com/ibm-messaging/event-streams-samples/blob/master/kafka-java-console-schema-sample/src/main/avro/com/eventstreams/samples/Message.avsc#L7