### PR TITLE
fix: The kafka binary link is not working anymore.

### DIFF
--- a/kafka-connect/Dockerfile
+++ b/kafka-connect/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine as builder
 RUN apk update
 RUN apk --no-cache add curl
 
-RUN curl -L "https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz" -o kafka.tgz
+RUN curl -L "https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz" -o kafka.tgz
 RUN mkdir /opt/kafka \
     && tar -xf kafka.tgz -C /opt/kafka --strip-components=1
 

--- a/kafka-mirrormaker/Dockerfile
+++ b/kafka-mirrormaker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine as builder
 RUN apk update
 RUN apk --no-cache add curl
 
-RUN curl -L "https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz" -o kafka.tgz
+RUN curl -L "https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz" -o kafka.tgz
 RUN mkdir /opt/kafka \
     && tar -xf kafka.tgz -C /opt/kafka --strip-components=1
 


### PR DESCRIPTION
I have updated the link to the latest 3.4.1 version.