### PR TITLE
feat: Update Docker Image to Use Official Kafka Images

### DIFF
--- a/kafka-connect/Dockerfile
+++ b/kafka-connect/Dockerfile
@@ -1,25 +1,13 @@
-# This dockerfile expects Connector jars to have been built under a `connectors` directory
-#
-FROM alpine as builder
+FROM apache/kafka:latest
 
-RUN apk update
-RUN apk --no-cache add curl
-
-RUN curl -L "https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz" -o kafka.tgz
-RUN mkdir /opt/kafka \
-    && tar -xf kafka.tgz -C /opt/kafka --strip-components=1
-
-FROM ibmjava:11
+USER root
 
 RUN addgroup --gid 5000 --system esgroup && \
-    adduser --uid 5000 --ingroup esgroup --system esuser
+    adduser --uid 5000 --ingroup esgroup --system esuser && \
+    mkdir -p /opt/kafka/plugins /opt/kafka/logs && \
+    chown -R esuser:esgroup /opt/kafka/plugins /opt/kafka/logs
 
-COPY --chown=esuser:esgroup --from=builder /opt/kafka/bin/ /opt/kafka/bin/
-COPY --chown=esuser:esgroup --from=builder /opt/kafka/libs/ /opt/kafka/libs/
-COPY --chown=esuser:esgroup --from=builder /opt/kafka/config/ /opt/kafka/config/
-RUN mkdir /opt/kafka/logs && chown esuser:esgroup /opt/kafka/logs
-
-COPY --chown=esuser:esgroup connectors /opt/connectors
+COPY --chown=esuser:esgroup connectors /opt/kafka/plugins/
 
 WORKDIR /opt/kafka
 
@@ -27,4 +15,4 @@ EXPOSE 8083
 
 USER esuser
 
-ENTRYPOINT ["./bin/connect-distributed.sh", "config/connect-distributed.properties"]
+ENTRYPOINT ["bin/connect-distributed.sh", "config/connect-distributed.properties"]


### PR DESCRIPTION
The current Docker image requires frequent updates whenever a new Kafka version is released. This is because the Kafka binary download link for older versions is removed when a new version is released, making the image outdated and prone to failures.

**Solution:**

This PR updates the Docker setup to use the official Kafka images. By doing so:

- We ensure compatibility with the latest Kafka versions as soon as they are released.
- The need to manually update the image whenever a new Kafka version is available is eliminated.
- The image remains reliable and up-to-date with minimal maintenance.

